### PR TITLE
Standardize contrib guidelines across public repos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+See the page titled "[Ways to Contribute](https://docs.oceanprotocol.com/concepts/contributing/)" in the Ocean Protocol documentation.


### PR DESCRIPTION
We're standardizing the Ocean Protocol contribution guidelines across all public repos by linking to one standard central page in the docs. It's easier to update one page than 30+ pages. (We currently have 36 public repos.)
