### PR TITLE
Make assetId always prefixed with "0x"

### DIFF
--- a/src/keeper/contracts/DIDRegistry.ts
+++ b/src/keeper/contracts/DIDRegistry.ts
@@ -15,21 +15,21 @@ export default class DIDRegistry extends ContractBase {
                                    value: string, ownerAddress: string): Promise<Receipt> {
 
         return this.send("registerAttribute",
-            ownerAddress, ["0x" + did, type, Web3Provider.getWeb3().utils.fromAscii(key), value],
+            ownerAddress, [did, type, Web3Provider.getWeb3().utils.fromAscii(key), value],
         )
     }
 
     public async getOwner(did: string): Promise<string> {
 
         return this.call("getOwner",
-            ["0x" + did],
+            [did],
         )
     }
 
     public async getUpdateAt(did: string): Promise<number> {
 
         const blockNum = await this.call("getUpdateAt",
-            ["0x" + did],
+            [did],
         )
 
         return parseInt(blockNum, 10)

--- a/src/keeper/contracts/Market.ts
+++ b/src/keeper/contracts/Market.ts
@@ -12,7 +12,7 @@ export default class OceanMarket extends ContractBase {
 
     // call functions (costs no gas)
     public async isAssetActive(assetId: string): Promise<boolean> {
-        return this.call("checkAsset", ["0x" + assetId])
+        return this.call("checkAsset", [assetId])
     }
 
     public async verifyOrderPayment(orderId: string): Promise<boolean> {
@@ -20,7 +20,7 @@ export default class OceanMarket extends ContractBase {
     }
 
     public async getAssetPrice(assetId: string): Promise<number> {
-        return this.call("getAssetPrice", ["0x" + assetId])
+        return this.call("getAssetPrice", [assetId])
             .then((price: string) => new BigNumber(price).toNumber())
     }
 
@@ -33,6 +33,6 @@ export default class OceanMarket extends ContractBase {
     }
 
     public async register(assetId: string, price: number, publisherAddress: string): Promise<Receipt> {
-        return this.send("register", publisherAddress, ["0x" + assetId, price])
+        return this.send("register", publisherAddress, [assetId, price])
     }
 }

--- a/src/keeper/contracts/ServiceAgreement.ts
+++ b/src/keeper/contracts/ServiceAgreement.ts
@@ -49,7 +49,7 @@ export default class ServiceAgreement extends ContractBase {
 
         return this.send("executeAgreement", publisherAddress, [
             serviceAgreementTemplateId, serviceAgreementSignatureHash, consumerAddress, valueHashes,
-            timeoutValues, serviceAgreementId, "0x" + did.replace("did:op:", ""),
+            timeoutValues, serviceAgreementId, did.replace("did:op:", ""),
         ])
     }
 }

--- a/src/keeper/contracts/conditions/AccessConditions.ts
+++ b/src/keeper/contracts/conditions/AccessConditions.ts
@@ -14,7 +14,7 @@ export default class AccessConditions extends ContractBase {
     public async grantAccess(serviceAgreementId: any, assetId: any, documentKeyId: any, publisherAddress: string)
         : Promise<Receipt> {
         return this.send("grantAccess", publisherAddress, [
-            serviceAgreementId, "0x" + assetId, "0x" + documentKeyId,
+            serviceAgreementId, assetId, documentKeyId,
         ])
     }
 }

--- a/src/keeper/contracts/conditions/PaymentConditions.ts
+++ b/src/keeper/contracts/conditions/PaymentConditions.ts
@@ -12,7 +12,7 @@ export default class PaymentConditions extends ContractBase {
     public async lockPayment(serviceAgreementId: string, assetId: string, price: number, consumerAddress: string)
         : Promise<Receipt> {
         return this.send("lockPayment", consumerAddress, [
-            serviceAgreementId, "0x" + assetId, price,
+            serviceAgreementId, assetId, price,
         ])
     }
 }

--- a/src/ocean/Ocean.ts
+++ b/src/ocean/Ocean.ts
@@ -67,7 +67,7 @@ export default class Ocean {
         const aquarius = AquariusProvider.getAquarius()
         const brizo = BrizoProvider.getBrizo()
 
-        const assetId: string = IdGenerator.generateId()
+        const assetId: string = IdGenerator.generatePrefixedId()
         const did: string = `did:op:${assetId}`
         const accessServiceDefinitionId: string = "0"
         const computeServiceDefintionId: string = "1"
@@ -183,7 +183,8 @@ export default class Ocean {
             event.listenOnce(async (data) => {
 
                 const sa: ServiceAgreement = new ServiceAgreement(data.returnValues.serviceAgreementId)
-                await sa.payAsset(id,
+                await sa.payAsset(
+                    id,
                     metadataService.metadata.base.price,
                     consumer,
                 )

--- a/src/ocean/ServiceAgreements/ServiceAgreementTemplate.ts
+++ b/src/ocean/ServiceAgreements/ServiceAgreementTemplate.ts
@@ -111,9 +111,9 @@ export default class ServiceAgreementTemplate extends OceanBase {
                     case "price":
                         return metadata.base.price
                     case "assetId":
-                        return "0x" + assetId
+                        return assetId
                     case "documentKeyId":
-                        return "0x" + assetId
+                        return assetId
                 }
 
                 return null

--- a/test/aquarius/Aquarius.test.ts
+++ b/test/aquarius/Aquarius.test.ts
@@ -85,7 +85,7 @@ describe("Aquarius", () => {
 
         it("should store a ddo", async () => {
 
-            const did: string = `did:op:${IdGenerator.generateId()}`
+            const did: string = `did:op:${IdGenerator.generatePrefixedId()}`
             const ddo: DDO = new DDO({
                 id: did,
             })
@@ -103,7 +103,7 @@ describe("Aquarius", () => {
 
         it("should store a ddo", async () => {
 
-            const did: string = `did:op:${IdGenerator.generateId()}`
+            const did: string = `did:op:${IdGenerator.generatePrefixedId()}`
             const ddo: DDO = new DDO({
                 id: did,
             })

--- a/test/keeper/DIDRegistry.test.ts
+++ b/test/keeper/DIDRegistry.test.ts
@@ -26,7 +26,7 @@ describe("DIDRegistry", () => {
 
         it("should register an attribute in a new did", async () => {
             const ownerAccount: Account = (await ocean.getAccounts())[0]
-            const did = IdGenerator.generateId()
+            const did = IdGenerator.generatePrefixedId()
             const providerKey = Web3Provider.getWeb3().utils.fromAscii("provider")
             const data = "my nice provider, is nice"
             const receipt = await didRegistry.registerAttribute(did, ValueType.DID, providerKey,
@@ -37,7 +37,7 @@ describe("DIDRegistry", () => {
 
         it("should register another attribute in the same did", async () => {
             const ownerAccount: Account = (await ocean.getAccounts())[0]
-            const did = IdGenerator.generateId()
+            const did = IdGenerator.generatePrefixedId()
             {
                 // register the first attribute
                 const providerKey = Web3Provider.getWeb3().utils.fromAscii("provider")
@@ -62,7 +62,7 @@ describe("DIDRegistry", () => {
 
         it("should get the owner of a did properly", async () => {
             const ownerAccount: Account = (await ocean.getAccounts())[0]
-            const did = IdGenerator.generateId()
+            const did = IdGenerator.generatePrefixedId()
             const providerKey = Web3Provider.getWeb3().utils.fromAscii("provider")
             const data = "my nice provider, is nice"
             await didRegistry.registerAttribute(did, ValueType.DID, providerKey,
@@ -74,7 +74,7 @@ describe("DIDRegistry", () => {
         })
 
         it("should get 0x00.. for a not registered did", async () => {
-            const owner = await didRegistry.getOwner("1234")
+            const owner = await didRegistry.getOwner("0x1234")
             assert(owner === "0x0000000000000000000000000000000000000000")
         })
 
@@ -84,7 +84,7 @@ describe("DIDRegistry", () => {
 
         it("should the block number of the last update of the did attribute", async () => {
             const ownerAccount: Account = (await ocean.getAccounts())[0]
-            const did = IdGenerator.generateId()
+            const did = IdGenerator.generatePrefixedId()
             const providerKey = Web3Provider.getWeb3().utils.fromAscii("provider")
             const data = "my nice provider, is nice"
             await didRegistry.registerAttribute(did, ValueType.DID, providerKey,

--- a/test/ocean/ServiceAgreement.test.ts
+++ b/test/ocean/ServiceAgreement.test.ts
@@ -23,7 +23,7 @@ let consumerAccount: Account
 let accessService: Service
 let metaDataService: Service
 
-const assetId: string = IdGenerator.generateId()
+const assetId: string = IdGenerator.generatePrefixedId()
 
 describe("ServiceAgreement", () => {
 

--- a/test/ocean/ServiceAgreement.test.ts
+++ b/test/ocean/ServiceAgreement.test.ts
@@ -44,7 +44,7 @@ describe("ServiceAgreement", () => {
 
         accessService = {
             type: "Access",
-            serviceDefinitionId: IdGenerator.generateId(),
+            serviceDefinitionId: "0",
             templateId: serviceAgreementTemplate.getId(),
             conditions,
         } as Service

--- a/test/ocean/ServiceAgreementTemplate.test.ts
+++ b/test/ocean/ServiceAgreementTemplate.test.ts
@@ -49,7 +49,7 @@ describe("ServiceAgreementTemplate", () => {
                 new ServiceAgreementTemplate(access)
             assert(serviceAgreementTemplate)
 
-            const conds = await serviceAgreementTemplate.getConditions(new MetaData(), IdGenerator.generateId())
+            const conds = await serviceAgreementTemplate.getConditions(new MetaData(), IdGenerator.generatePrefixedId())
             assert(conds)
         })
     })


### PR DESCRIPTION
Prefix the assetId with `0x` and have that saved in the did. 

Update all references to reflect the new format.

Fixes issue when consuming an asset registered in squid-py.