### PR TITLE
return file urls

### DIFF
--- a/src/ocean/Ocean.ts
+++ b/src/ocean/Ocean.ts
@@ -18,7 +18,6 @@ import Config from "../models/Config"
 import ValueType from "../models/ValueType"
 import SecretStoreProvider from "../secretstore/SecretStoreProvider"
 import Logger from "../utils/Logger"
-import WebServiceConnectorProvider from "../utils/WebServiceConnectorProvider"
 import Account from "./Account"
 import DID from "./DID"
 import IdGenerator from "./IdGenerator"
@@ -221,7 +220,6 @@ export default class Ocean {
 
         accessEvent.listenOnce(async () => {
             Logger.log("Awesome; got a AccessGranted Event. Let's download the asset files.")
-            const webConnector = WebServiceConnectorProvider.getConnector()
             const contentUrls = await SecretStoreProvider
                 .getSecretStore()
                 .decryptDocument(d.getId(), metadataService.metadata.base.contentUrls[0])

--- a/src/ocean/Ocean.ts
+++ b/src/ocean/Ocean.ts
@@ -233,15 +233,8 @@ export default class Ocean {
                 let url: string = serviceUrl + `?url=${cUrl}`
                 url = url + `&serviceAgreementId=${serviceAgreementId}`
                 url = url + `&consumerAddress=${consumer.getId()}`
-                Logger.log("Fetching asset from: ", url)
-                const response: any = await webConnector.get(url)
-                const responseBuffer: Buffer = await response.buffer()
-                const urlParts: string[] = cUrl.split("/")
-                const filename: string = urlParts[urlParts.length - 1]
-                Logger.debug(`Got response: filename is ${filename}, url is ${response.url}`)
-                files.push(responseBuffer.toString("utf8"))
+                files.push(url)
             }
-            Logger.log("Done downloading asset files.")
 
             cb(files)
         })


### PR DESCRIPTION
## Description

Make squid-js return urls to be handled by developers code and not started inside squid-js. Also *.buffer* methods are not available in browser. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation