### PR TITLE
Fix page numbers in search queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,12 @@ before_script:
   - ganache-cli --port 18545 > ganache-cli.log &
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
-  - export AQUARIUS_VERSION=v0.2.1
-  - export BRIZO_VERSION=v0.3.4
-  - export KEEPER_VERSION=v0.9.0
+  - export AQUARIUS_VERSION=v0.2.2
+  - export BRIZO_VERSION=v0.3.5
+  - export KEEPER_VERSION=v0.9.1
   - export KEEPER_OWNER_ROLE_ADDRESS="0xe2DD09d719Da89e5a3D0F2549c7E24566e947260"
   - bash -x start_ocean.sh --latest --no-pleuston --local-spree-node 2>&1 > start_ocean.log &
   - cd ..
-  - ./scripts/unlock-spree-accounts.sh  2>&1 > /dev/null &
 
 script:
   - export ETH_PORT=18545; npm run test:cover

--- a/integration/ocean/SearchAsset.test.ts
+++ b/integration/ocean/SearchAsset.test.ts
@@ -65,7 +65,7 @@ describe("Search Asset", () => {
 
     it("should be able to do a query to get a list of DDOs", async () => {
         const {results: ddos} = await ocean.assets.query({
-            page: 0,
+            page: 1,
             offset: 1,
             query: {
                 text: [`Test2${testHash}`],

--- a/src/ocean/OceanAssets.ts
+++ b/src/ocean/OceanAssets.ts
@@ -276,7 +276,7 @@ export class OceanAssets extends Instantiable {
     public async search(text: string) {
         return this.ocean.aquarius.queryMetadataByText({
             text,
-            page: 0,
+            page: 1,
             offset: 100,
             query: {
                 value: 1,

--- a/test/aquarius/Aquarius.test.ts
+++ b/test/aquarius/Aquarius.test.ts
@@ -18,7 +18,7 @@ describe("Aquarius", () => {
 
         const query = {
             offset: 100,
-            page: 0,
+            page: 1,
             query: {
                 value: 1,
             },
@@ -56,7 +56,7 @@ describe("Aquarius", () => {
 
         const query = {
             offset: 100,
-            page: 0,
+            page: 1,
             query: {
                 value: 1,
             },

--- a/test/ocean/Ocean.test.ts
+++ b/test/ocean/Ocean.test.ts
@@ -49,7 +49,7 @@ describe("Ocean", () => {
         it("should search for assets", async () => {
             const query = {
                 offset: 100,
-                page: 0,
+                page: 1,
                 query: {
                     value: 1,
                 },


### PR DESCRIPTION
Currently `ocean.assets.search('some text')` is broken, Aquarius will return 500 error when `page: 0` is sent as part of search query.

This PR fixes that by setting `page: 1` in all search queries. Also bump versions in Travis and fix path to renamed script.