### PR TITLE
Generate typedoc json during build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ src/
 tsconfig.json
 tslint.json
 oceanprotocol-squid-*.tgz
+squid-js.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -3797,7 +3797,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3818,12 +3819,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3838,17 +3841,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3965,7 +3971,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3977,6 +3984,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3991,6 +3999,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3998,12 +4007,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4022,6 +4033,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4102,7 +4114,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4114,6 +4127,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4199,7 +4213,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4235,6 +4250,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4254,6 +4270,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4297,12 +4314,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9705,7 +9724,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run clean && npm run build:tsc && npm run build:dist",
     "build:tsc": "tsc --sourceMap",
     "build:metadata": "./scripts/get-metadata.js > src/metadata.json",
-    "build:dist": "cross-env NODE_ENV=production webpack",
+    "build:dist": "cross-env NODE_ENV=production webpack && npm run doc:json",
     "build:watch": "tsc -w",
     "test": "mocha",
     "test:watch": "mocha -w --watch-extensions js,ts,json",
@@ -24,6 +24,7 @@
     "lint": "eslint --ignore-path .gitignore --ext .ts,.tsx .",
     "format": "prettier --parser typescript --ignore-path .gitignore --write '**/*.{js,jsx,ts,tsx}'",
     "doc": "typedoc --mode modules --out ./doc/ ./src/",
+    "doc:json": "./scripts/typedoc.js",
     "merge-coverages": "npx lcov-result-merger \"coverage/*/lcov.info\" coverage/lcov.info",
     "report-coverage": "npm run report-coverage:unit && npm run report-coverage:integration",
     "report-coverage:unit": "cat coverage/unit/lcov.info | codacy-coverage --token 71ef0d15f6f04ac29b31d704b28f866a",
@@ -80,6 +81,7 @@
     "mocha": "^6.1.4",
     "mock-local-storage": "^1.1.8",
     "nyc": "^14.1.1",
+    "ora": "^3.4.0",
     "prettier": "^1.18.2",
     "source-map-support": "^0.5.12",
     "truffle-hdwallet-provider": "^1.0.10",
@@ -111,7 +113,6 @@
   },
   "release-it": {
     "hooks": {
-      "after:init": "npm test",
       "after:bump": "npm run changelog"
     },
     "plugins": {
@@ -126,7 +127,10 @@
       "tagName": "v${version}"
     },
     "github": {
-      "release": true
+      "release": true,
+      "assets": [
+        "dist/squid-js.json"
+      ]
     },
     "npm": {
       "publish": false

--- a/scripts/typedoc.js
+++ b/scripts/typedoc.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/* eslint-disable security/detect-non-literal-fs-filename */
+
+const fs = require('fs')
+const typedoc = require('typedoc')
+const typescript = require('typescript')
+const ora = require('ora')
+const squidJsPackage = require('../package.json')
+
+const { description, version } = squidJsPackage
+
+// Setup our paths, relative to project root
+const outPath = './dist/squid-js.json'
+const files = ['./src/squid.ts']
+
+// specifically point to tsconfig, otherwise TypeDoc fails
+const config = typescript.findConfigFile(
+    './tsconfig.js',
+    typescript.sys.fileExists
+)
+
+const generateJson = () => {
+    const spinnerTypedoc = ora('Generating TypeDoc json...').start()
+
+    // Setup our TypeDoc app
+    const app = new typedoc.Application({
+        tsconfig: config
+    })
+
+    const src = app.expandInputFiles(files)
+    const project = app.convert(src)
+
+    // Generate the JSON file
+    app.generateJson(project, outPath)
+
+    // Parse and modify json output
+    const jsonOrig = JSON.parse(fs.readFileSync(outPath, 'utf8'))
+
+    const jsonFinal = {
+        info: {
+            title: 'Squid-js',
+            description,
+            version,
+            sourceUrl: 'https://github.com/oceanprotocol/squid-js/blob/master/'
+        },
+        ...jsonOrig
+    }
+
+    fs.writeFileSync(outPath, JSON.stringify(jsonFinal, null, 4))
+
+    spinnerTypedoc.succeed('Generated TypeDoc json.')
+}
+
+generateJson()


### PR DESCRIPTION
Move over `typedoc.js` from https://github.com/oceanprotocol/docs to automatically generate TypeDoc json during every production build. This then gets added as GitHub release artifact for every release. Which then can be used by docs to regenerate API docs automatically on every build, instead of manually updating git submodule over there.

Closes #235. Prerequisite for https://github.com/oceanprotocol/docs/issues/195.

![giphy](https://user-images.githubusercontent.com/90316/60039283-a4867400-96b6-11e9-986d-b3e1b6bb2105.gif)