### PR TITLE
hot fix: revert esModuleInterop

### DIFF
--- a/integration/config.ts
+++ b/integration/config.ts
@@ -1,5 +1,5 @@
-import HDWalletProvider from '@truffle/hdwallet-provider'
 import { Config } from '../src'
+const HDWalletProvider = require('@truffle/hdwallet-provider')
 
 const configJson: Config = {
     nodeUri: 'http://localhost:8545',

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "lib": ["es6", "es7", "dom"],
-    "noUnusedLocals": true,
-    "esModuleInterop": true
+    "noUnusedLocals": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -115,15 +115,13 @@
   },
   "release-it": {
     "hooks": {
-      "before:init": "npm run doc:json",
-      "after:bump": "npm run changelog"
+      "after:bump": "npm run changelog && npm run doc:json"
     },
     "plugins": {
       "@release-it/bumper": {
         "out": [
           "package.json",
-          "package-lock.json",
-          "dist/squid-js.json"
+          "package-lock.json"
         ]
       }
     },

--- a/src/Instantiable.abstract.ts
+++ b/src/Instantiable.abstract.ts
@@ -1,4 +1,4 @@
-import Web3 from 'web3'
+import * as Web3 from 'web3'
 import Config from './models/Config'
 import { Logger, LoggerInstance, LogLevel } from './utils'
 import Web3Provider from './keeper/Web3Provider'

--- a/src/ddo/DDO.ts
+++ b/src/ddo/DDO.ts
@@ -1,4 +1,4 @@
-import Web3 from 'web3'
+import * as Web3 from 'web3'
 import Web3Provider from '../keeper/Web3Provider'
 import LoggerInstance from '../utils/Logger'
 import { Ocean } from '../ocean/Ocean'

--- a/src/keeper/Web3Provider.ts
+++ b/src/keeper/Web3Provider.ts
@@ -1,4 +1,4 @@
-import Web3 from 'web3'
+import * as Web3 from 'web3'
 import Config from '../models/Config'
 
 export default class Web3Provider {

--- a/test/Squid.test.ts
+++ b/test/Squid.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import * as assert from 'assert'
 import * as squid from '../src/squid'
 
 describe('Squid', () => {

--- a/test/aquarius/Aquarius.test.ts
+++ b/test/aquarius/Aquarius.test.ts
@@ -1,5 +1,5 @@
 import { assert, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 import { Ocean } from '../../src/ocean/Ocean'
 import { Aquarius, SearchQuery } from '../../src/aquarius/Aquarius'
 import { DDO } from '../../src/ddo/DDO'

--- a/test/ddo/DDO.test.ts
+++ b/test/ddo/DDO.test.ts
@@ -1,6 +1,6 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
-import Web3 from 'web3'
+import * as spies from 'chai-spies'
+import * as Web3 from 'web3'
 
 import { DDO } from '../../src/ddo/DDO'
 import { Service } from '../../src/ddo/Service'

--- a/test/keeper/EventHandler.test.ts
+++ b/test/keeper/EventHandler.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 import { EventHandler } from '../../src/keeper/EventHandler'
 import { Ocean } from '../../src/ocean/Ocean'
 import config from '../config'

--- a/test/ocean/DID.test.ts
+++ b/test/ocean/DID.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import * as assert from 'assert'
 import DID from '../../src/ocean/DID'
 
 describe('DID', () => {

--- a/test/ocean/Ocean.test.ts
+++ b/test/ocean/Ocean.test.ts
@@ -1,5 +1,5 @@
 import { assert, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import { SearchQuery } from '../../src/aquarius/Aquarius'
 import Account from '../../src/ocean/Account'

--- a/test/ocean/OceanAccounts.test.ts
+++ b/test/ocean/OceanAccounts.test.ts
@@ -1,5 +1,5 @@
 import { assert, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import config from '../config'
 import Account from '../../src/ocean/Account'

--- a/test/ocean/OceanAuth.test.ts
+++ b/test/ocean/OceanAuth.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import config from '../config'
 import Account from '../../src/ocean/Account'

--- a/test/ocean/OceanSecretStore.test.ts
+++ b/test/ocean/OceanSecretStore.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import Account from '../../src/ocean/Account'
 import { Ocean } from '../../src/ocean/Ocean'

--- a/test/ocean/utils/SignatureUtils.test.ts
+++ b/test/ocean/utils/SignatureUtils.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import config from '../../config'
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "lib": ["es6", "es7"],
-    "noUnusedLocals": true,
-    "esModuleInterop": true
+    "noUnusedLocals": true
   }
 }

--- a/test/utils/SubscribableObserver.test.ts
+++ b/test/utils/SubscribableObserver.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import { SubscribableObserver } from '../../src/utils/SubscribableObserver'
 

--- a/test/utils/SubscribablePromise.test.ts
+++ b/test/utils/SubscribablePromise.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, spy, use } from 'chai'
-import spies from 'chai-spies'
+import * as spies from 'chai-spies'
 
 import { SubscribablePromise } from '../../src/utils/SubscribablePromise'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": true,
     "module": "commonjs",
     "target": "es5",
-    "esModuleInterop": true,
     "noImplicitAny": false,
     "removeComments": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Looks like `esModuleInterop` is no good preventing Web3 from loading so revert all that.